### PR TITLE
Remove pin on uv versions in `tests` GitHub workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,9 +25,7 @@ jobs:
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v5
         with:
-          # It is considered best practice (by uv's developers) to pin to a specific uv version
-          # https://docs.astral.sh/uv/guides/integration/github/#installation
-          version: 0.6.3
+          pyproject-file: "pyproject.toml"
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
@@ -46,9 +44,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # It is considered best practice (by uv's developers) to pin to a specific uv version
-          # https://docs.astral.sh/uv/guides/integration/github/#installation
-          version: 0.6.3
+          pyproject-file: "pyproject.toml"
 
       - name: Install uv-managed python version and the project
         run: uv sync --extra cpu


### PR DESCRIPTION
Configure `astral-sh/setup-uv` to inspect the `pyproject.toml` to detect the version to use, since fix for support of pep440 version specifiers (see https://github.com/astral-sh/setup-uv/issues/264)